### PR TITLE
feature: 컴포넌트 댓글 리스트 조회 api 구현

### DIFF
--- a/src/main/java/woori_design_web/back_woori_design_web/controller/ComponentsRestController.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/controller/ComponentsRestController.java
@@ -1,0 +1,34 @@
+package woori_design_web.back_woori_design_web.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import woori_design_web.back_woori_design_web.dto.comment.CommentDto.CommentListResponse;
+import woori_design_web.back_woori_design_web.dto.common.ResponseDto;
+import woori_design_web.back_woori_design_web.service.components.ComponentsService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/components")
+public class ComponentsRestController {
+    private final ComponentsService componentsService;
+
+    /**
+     * 컴포넌트 기반 댓글 목록 조회
+     * @param componentId 컴포넌트 ID
+     * @return CommentListResponse (componentId, comments) 컴포넌트 댓글 목록 응답
+     */
+    @GetMapping("/{componentId}/comments")
+    public ResponseEntity<ResponseDto<CommentListResponse>> getCommentsByComponent(@PathVariable long componentId) {
+        try {
+            Long userId = 1L; // 사용자 ID (null 가능, 추후 인증 서비스 구현 시 해당 메서드로 대체 예정)
+            CommentListResponse response = componentsService.getCommentsByComponent(componentId, userId);
+            return ResponseEntity.ok(new ResponseDto<>(ResponseDto.Status.SUCCESS, "댓글 목록 조회 성공", response));
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body(new ResponseDto<>(ResponseDto.Status.FAILURE, "댓글 목록 조회 실패", null));
+        }
+    }
+}

--- a/src/main/java/woori_design_web/back_woori_design_web/controller/ComponentsRestController.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/controller/ComponentsRestController.java
@@ -2,6 +2,8 @@ package woori_design_web.back_woori_design_web.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,7 +26,12 @@ public class ComponentsRestController {
     @GetMapping("/{componentId}/comments")
     public ResponseEntity<ResponseDto<CommentListResponse>> getCommentsByComponent(@PathVariable long componentId) {
         try {
-            Long userId = 1L; // 사용자 ID (null 가능, 추후 인증 서비스 구현 시 해당 메서드로 대체 예정)
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            // 추후 사용자 ID 가져오는 로직 추가
+//            Long userId = (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails)
+//                    ? ((CustomUserDetails) authentication.getPrincipal()).getId()
+//                    : null;
+            Long userId = null;
             CommentListResponse response = componentsService.getCommentsByComponent(componentId, userId);
             return ResponseEntity.ok(new ResponseDto<>(ResponseDto.Status.SUCCESS, "댓글 목록 조회 성공", response));
         } catch (Exception e) {

--- a/src/main/java/woori_design_web/back_woori_design_web/dto/comment/CommentDto.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/dto/comment/CommentDto.java
@@ -1,0 +1,34 @@
+package woori_design_web.back_woori_design_web.dto.comment;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CommentDto() {
+    /**
+     * 컴포넌트 댓글 조회 응답 Dto
+     * @param componentId
+     * @param comments
+     */
+    @Builder
+    public record CommentListResponse(
+            long componentId,
+            List<Comments> comments
+    ) {
+        @Builder
+        public record Comments(
+                long id,
+                UserInfo user,
+                String content,
+                LocalDate createdAt,
+                boolean isMine // 사용자 본인이 작성한 댓글 판단 여부
+        ) {
+            @Builder
+            public record UserInfo(
+                    long id,
+                    String nickname
+            ) {}
+        }
+    }
+}

--- a/src/main/java/woori_design_web/back_woori_design_web/dto/comment/CommentDto.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/dto/comment/CommentDto.java
@@ -2,7 +2,7 @@ package woori_design_web.back_woori_design_web.dto.comment;
 
 import lombok.Builder;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record CommentDto() {
@@ -14,14 +14,14 @@ public record CommentDto() {
     @Builder
     public record CommentListResponse(
             long componentId,
-            List<Comments> comments
+            List<CommentsResponse> comments
     ) {
         @Builder
-        public record Comments(
+        public record CommentsResponse(
                 long id,
                 UserInfo user,
                 String content,
-                LocalDate createdAt,
+                LocalDateTime createdAt,
                 boolean isMine // 사용자 본인이 작성한 댓글 판단 여부
         ) {
             @Builder

--- a/src/main/java/woori_design_web/back_woori_design_web/entity/Comment.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/entity/Comment.java
@@ -2,13 +2,15 @@ package woori_design_web.back_woori_design_web.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Table(name = "COMMENT")
 @AllArgsConstructor
 @NoArgsConstructor
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,5 +33,4 @@ public class Comment {
      */
     @Column(columnDefinition = "text")
     private String content;
-
 }

--- a/src/main/java/woori_design_web/back_woori_design_web/repository/CommentRepository.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/repository/CommentRepository.java
@@ -1,0 +1,11 @@
+package woori_design_web.back_woori_design_web.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woori_design_web.back_woori_design_web.entity.Comment;
+import woori_design_web.back_woori_design_web.entity.Components;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByComponents(Components components);
+}

--- a/src/main/java/woori_design_web/back_woori_design_web/repository/CommentRepository.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/repository/CommentRepository.java
@@ -7,5 +7,5 @@ import woori_design_web.back_woori_design_web.entity.Components;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findByComponents(Components components);
+    List<Comment> findByComponentsId(Long componentsId);
 }

--- a/src/main/java/woori_design_web/back_woori_design_web/repository/ComponentsRepository.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/repository/ComponentsRepository.java
@@ -1,0 +1,8 @@
+package woori_design_web.back_woori_design_web.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import woori_design_web.back_woori_design_web.entity.Components;
+
+public interface ComponentsRepository extends JpaRepository<Components, Long> {
+
+}

--- a/src/main/java/woori_design_web/back_woori_design_web/service/components/ComponentsService.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/service/components/ComponentsService.java
@@ -26,9 +26,7 @@ public class ComponentsService {
         List<CommentsResponse> commentsResponseList = comments.stream()
                 .map(comment -> {
                     Member member = comment.getMember();
-                    boolean isMine = false;
-
-                    if (userId != null) isMine = member.getId().equals(userId);
+                    boolean isMine = member.getId().equals(userId);
 
                     return CommentsResponse.builder()
                             .id(comment.getId())

--- a/src/main/java/woori_design_web/back_woori_design_web/service/components/ComponentsService.java
+++ b/src/main/java/woori_design_web/back_woori_design_web/service/components/ComponentsService.java
@@ -1,0 +1,51 @@
+package woori_design_web.back_woori_design_web.service.components;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import woori_design_web.back_woori_design_web.dto.comment.CommentDto.CommentListResponse;
+import woori_design_web.back_woori_design_web.dto.comment.CommentDto.CommentListResponse.CommentsResponse;
+import woori_design_web.back_woori_design_web.entity.Comment;
+import woori_design_web.back_woori_design_web.entity.Member;
+import woori_design_web.back_woori_design_web.repository.CommentRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ComponentsService {
+    private final CommentRepository commentRepository;
+
+    /**
+     * 컴포넌트 기반 댓글 목록 조회
+     */
+    public CommentListResponse getCommentsByComponent(long componentsId, Long userId) {
+        List<Comment> comments = commentRepository.findByComponentsId(componentsId);
+        List<CommentsResponse> commentsResponseList = comments.stream()
+                .map(comment -> {
+                    Member member = comment.getMember();
+                    boolean isMine = false;
+
+                    if (userId != null) isMine = member.getId().equals(userId);
+
+                    return CommentsResponse.builder()
+                            .id(comment.getId())
+                            .user(CommentsResponse.UserInfo.builder()
+                                    .id(member.getId())
+                                    .nickname(member.getName())
+                                    .build())
+                            .content(comment.getContent())
+                            .createdAt(comment.getCreatedAt())
+                            .isMine(isMine)
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        return CommentListResponse.builder()
+                .componentId(componentsId)
+                .comments(commentsResponseList)
+                .build();
+    }
+}

--- a/src/test/java/woori_design_web/back_woori_design_web/service/components/ComponentsServiceTest.java
+++ b/src/test/java/woori_design_web/back_woori_design_web/service/components/ComponentsServiceTest.java
@@ -1,0 +1,59 @@
+package woori_design_web.back_woori_design_web.service.components;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import woori_design_web.back_woori_design_web.dto.comment.CommentDto.CommentListResponse;
+import woori_design_web.back_woori_design_web.entity.*;
+import woori_design_web.back_woori_design_web.repository.CommentRepository;
+import woori_design_web.back_woori_design_web.repository.ComponentsRepository;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ComponentsServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private ComponentsRepository componentsRepository;
+
+    @InjectMocks
+    private ComponentsService componentsService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testGetCommentsByComponent() throws Exception {
+        long componentId = 1L;
+        Long userId = null;
+
+        Member member = new Member(1L, "memberName", "password", SocialType.LOCAL, "email", Role.USER, UserStatus.ACTIVE, false, null, null, null, null);
+        Components components = new Components(componentId, "componentName", "content", Authority.FREE, "/path");
+        Comment comment1 = new Comment(1L, member, components, "content1");
+        Comment comment2 = new Comment(2L, member, components, "content2");
+
+        List<Comment> comments = Arrays.asList(comment1, comment2);
+
+        when(commentRepository.findByComponentsId(componentId)).thenReturn(comments);
+
+        CommentListResponse response = componentsService.getCommentsByComponent(componentId, userId);
+
+        assertNotNull(response);
+        assertEquals(2, response.comments().size());
+        assertEquals(componentId, response.componentId());
+        assertEquals("content1", response.comments().get(0).content());
+        assertEquals("content2", response.comments().get(1).content());
+
+        verify(commentRepository, times(1)).findByComponentsId(componentId);
+    }
+}


### PR DESCRIPTION
## 🔎 관련 이슈
#8 

## 🔎 작업 내용
컴포넌트 댓글 리스트 조회 api 구현

## 🔎 참고사항
- 추후 로그인 사용자 ID 가져오는 로직 추가 예정 (인가코드 구현완료 후)
- Comment 엔티티 @Getter, extends BaseTimeEntity 추가



